### PR TITLE
Fixed subscribe to authState code

### DIFF
--- a/docs/Auth-with-Ionic2.md
+++ b/docs/Auth-with-Ionic2.md
@@ -273,7 +273,7 @@ export class AuthService {
 
   constructor(public afAuth: AngularFireAuth) {
     this.authState = afAuth.authState;
-    afAuth.subscribe((user: firebase.User) => {
+    this.authState.subscribe((user: firebase.User) => {
       this.currentUser = user;
     });
   }


### PR DESCRIPTION
afAuth.subscribe didn't have the subscribe object, though this.authState does

### Checklist

   - Issue number for this PR: #960 (required)
   - Docs included?: No, documentation
   - Test units included?: No
   - e2e tests included?: No
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? No

### Description

Incorrect docu pointing to afAuth.subscribe, it should be attached to the new this.authState object.
Updating documentation so others don't go down the wrong garden path like me
